### PR TITLE
New Processor: Mutate

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	Output_Dummy         map[string]*output.DummyConfig
 	Processor_Anonymize  map[string]*processor.AnonymizeConfig
 	Processor_Metrics    map[string]*processor.MetricsConfig
+	Processor_Mutate     map[string]*processor.MutateConfig
 }
 
 type Definition struct {

--- a/src/container.go
+++ b/src/container.go
@@ -132,6 +132,11 @@ func (c *Container) GetPostProcessor(key string) intf.PostProcessor {
 		return processor.NewMetrics(metricsConfig)
 	}
 
+	mConfig, ok := GetConfig().Processor_Mutate[key]
+	if ok {
+		return processor.NewMutate(mConfig)
+	}
+
 	Critical("Unable to find '%s' processor definition", key)
 	return nil
 }

--- a/src/processor/mutate.go
+++ b/src/processor/mutate.go
@@ -1,0 +1,88 @@
+package processor
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/mcuadros/harvesterd/src/intf"
+	. "github.com/mcuadros/harvesterd/src/logger"
+	"github.com/mcuadros/harvesterd/src/processor/mutate"
+)
+
+const FIELDSEP = '.'
+
+type MutateConfig struct {
+	Verbose bool
+	Cast    []string
+}
+
+func (mc *MutateConfig) ParseOperations() []*mutate.Operation {
+	var operations []*mutate.Operation
+	if len(mc.Cast) > 0 {
+		for _, rawparams := range mc.Cast {
+			op := mc.parseOperation(mutate.CAST, rawparams)
+			operations = append(operations, op)
+		}
+	}
+	return operations
+}
+
+func (p *MutateConfig) parseOperation(id mutate.OperationId, rawparams string) *mutate.Operation {
+	// Parse the raw string into:
+	// * single keywords with no spaces
+	// * groups of single-quoted strings
+	re := regexp.MustCompile("[^' ]+|'[^']+'")
+	splitted := re.FindAllString(rawparams, -1)
+	for i, s := range splitted {
+		splitted[i] = strings.Trim(s, "'")
+	}
+	return &mutate.Operation{
+		Id:     id,
+		Field:  strings.Split(splitted[0], string(FIELDSEP)),
+		Params: splitted[1:],
+	}
+}
+
+type Mutate struct {
+	operations []*mutate.Operation
+	channel    chan intf.Record
+	verbose    bool
+	isAlive    bool
+}
+
+func NewMutate(config *MutateConfig) *Mutate {
+	processor := Mutate{
+		operations: []*mutate.Operation{},
+	}
+	processor.SetConfig(config)
+	processor.Setup()
+
+	return &processor
+}
+
+func (p *Mutate) SetConfig(config *MutateConfig) {
+	p.verbose = config.Verbose
+	p.operations = config.ParseOperations()
+}
+
+func (p *Mutate) SetChannel(channel chan intf.Record) {
+	p.channel = channel
+}
+
+func (p *Mutate) Do(record intf.Record) bool {
+	for _, op := range p.operations {
+		err := op.Apply(map[string]interface{}(record))
+		if err != nil && p.verbose {
+			Warning(err.Error())
+		}
+	}
+	return true
+}
+
+func (p *Mutate) Setup() {
+	p.isAlive = true
+}
+
+func (p *Mutate) Teardown() {
+	p.isAlive = false
+}

--- a/src/processor/mutate/base_test.go
+++ b/src/processor/mutate/base_test.go
@@ -1,0 +1,10 @@
+package mutate
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+// Hook up gocheck into the "go test" runner.
+func Test(t *testing.T) { TestingT(t) }

--- a/src/processor/mutate/cast.go
+++ b/src/processor/mutate/cast.go
@@ -1,0 +1,58 @@
+package mutate
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+const (
+	INT  = "int"
+	DATE = "date"
+)
+
+func cast(value interface{}, fn string, params ...string) (interface{}, error) {
+	switch fn {
+	case INT:
+		switch value.(type) {
+		case string:
+			result, err := strconv.Atoi(value.(string))
+			if err != nil {
+				return value, err
+			} else {
+				return result, nil
+			}
+		case int:
+		default:
+			return value, fmt.Errorf("cast: invalid input value `%s`", value)
+		}
+	case DATE:
+		switch value.(type) {
+		case string:
+			if len(params) < 1 {
+				return value, fmt.Errorf("cast: cast string to date requires a format, can't cast `%s`", value)
+			}
+			var err error
+			var result time.Time
+			for _, format := range params {
+				result, err = time.Parse(format, value.(string))
+				if err == nil {
+					break
+				}
+			}
+			if err != nil {
+				return value, err
+			} else {
+				return result, nil
+			}
+		case int:
+			return time.Unix(int64(value.(int)), 0), nil
+		default:
+			return value, fmt.Errorf("cast: invalid input value `%s`", value)
+		}
+	default:
+		return value, fmt.Errorf("cast: unrecognized cast function `%s`", fn)
+	}
+
+	return value, nil
+}

--- a/src/processor/mutate/cast_test.go
+++ b/src/processor/mutate/cast_test.go
@@ -1,0 +1,80 @@
+package mutate
+
+import (
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+type CastSuite struct{}
+
+var _ = Suite(&CastSuite{})
+
+func (s *CastSuite) TestCastINT(c *C) {
+	var value interface{}
+	var err error
+
+	value = "1234"
+	value, err = cast(value, INT)
+	c.Assert(err, IsNil)
+	c.Assert(value, Equals, 1234)
+
+	value = 1234
+	value, err = cast(value, INT)
+	c.Assert(err, IsNil)
+	c.Assert(value, Equals, 1234)
+
+	value = "not int"
+	value, err = cast(value, INT)
+	c.Assert(err, NotNil)
+	c.Assert(value, Equals, "not int")
+
+	value = struct{}{}
+	value, err = cast(value, INT)
+	c.Assert(err, NotNil)
+	c.Assert(value, Equals, struct{}{})
+}
+
+func (s *CastSuite) TestCastDATE(c *C) {
+	var value interface{}
+	var err error
+	var t time.Time
+
+	value = "2015-09-16T09:15:30"
+	value, err = cast(value, DATE, "2006-01-02T15:04:05")
+	c.Assert(err, IsNil)
+	t = value.(time.Time)
+	c.Assert(t.Unix(), Equals, int64(1442394930))
+
+	value = "Sep 15"
+	value, err = cast(value, DATE, "2006-01-02T15:04:05", "Jan 06")
+	c.Assert(err, IsNil)
+	t = value.(time.Time)
+	c.Assert(t.Unix(), Equals, int64(1441065600))
+
+	value = 1442394930
+	value, err = cast(value, DATE)
+	c.Assert(err, IsNil)
+	t = value.(time.Time)
+	c.Assert(t.Unix(), Equals, int64(1442394930))
+
+	value = "not date"
+	value, err = cast(value, DATE, "2006-01-02T15:04:05")
+	c.Assert(err, NotNil)
+	c.Assert(value, Equals, "not date")
+
+	value = struct{}{}
+	value, err = cast(value, DATE, "2006-01-02T15:04:05")
+	c.Assert(err, NotNil)
+	c.Assert(value, Equals, struct{}{})
+}
+
+func (s *CastSuite) TestCastUnknown(c *C) {
+	var value interface{}
+	var err error
+
+	value = "irrelevant test value"
+	value, err = cast(value, "unsupported-function")
+	c.Assert(err, NotNil)
+	c.Assert(value, Equals, "irrelevant test value")
+}

--- a/src/processor/mutate/operation.go
+++ b/src/processor/mutate/operation.go
@@ -1,0 +1,93 @@
+package mutate
+
+import (
+	"fmt"
+)
+
+type OperationId int
+
+const (
+	CAST OperationId = 1 << iota
+)
+
+type Operation struct {
+	Id     OperationId
+	Field  []string
+	Params []string
+}
+
+// Applies the Operation o to a record, recursively entering the
+// maps and slices to get to the element in the path specified in o.Field
+func (o Operation) Apply(record interface{}) error {
+	var key string
+	var isLeaf bool
+	if len(o.Field) > 0 {
+		key = o.Field[0]
+		o.Field = o.Field[1:]
+	}
+	isLeaf = len(o.Field) == 0
+
+	switch record.(type) {
+	case []interface{}:
+		r := record.([]interface{})
+		if key == "*" {
+			var firsterr error
+			for i := range r {
+				var err error
+				if isLeaf {
+					r[i], err = o.execute(r[i])
+				} else {
+					err = o.Apply(r[i])
+				}
+				if firsterr == nil && err != nil {
+					firsterr = err
+				}
+			}
+			return firsterr
+		} else {
+			return fmt.Errorf("mutate: slice found and key `%s` was in the path", key)
+		}
+	case map[string]interface{}:
+		r := record.(map[string]interface{})
+		if key == "*" {
+			var firsterr error
+			for k := range r {
+				var err error
+				if isLeaf {
+					r[k], err = o.execute(r[k])
+				} else {
+					err = o.Apply(r[k])
+				}
+				if firsterr == nil && err != nil {
+					firsterr = err
+				}
+			}
+			return firsterr
+		} else if _, ok := r[key]; ok {
+			var err error
+			if isLeaf {
+				r[key], err = o.execute(r[key])
+			} else {
+				err = o.Apply(r[key])
+			}
+			return err
+		} else {
+			return fmt.Errorf("mutate: key `%s` was not found in subtree `%s`", key, r)
+		}
+	default:
+		return fmt.Errorf("mutate: not map or slice element found in the path")
+	}
+	return nil
+}
+
+// Executes the action with id o.ID over `value`
+func (o *Operation) execute(value interface{}) (interface{}, error) {
+	switch o.Id {
+	case CAST:
+		if len(o.Params) < 1 {
+			return value, fmt.Errorf("mutate: wrong number of params for function `cast`, at least 1 expected, %s found", o.Params)
+		}
+		return cast(value, o.Params[0], o.Params[1:]...)
+	}
+	return value, fmt.Errorf("mutate: operation %d not implemented", o.Id)
+}

--- a/src/processor/mutate/operation_test.go
+++ b/src/processor/mutate/operation_test.go
@@ -1,0 +1,75 @@
+package mutate
+
+import . "gopkg.in/check.v1"
+
+type OperationSuite struct{}
+
+var _ = Suite(&OperationSuite{})
+
+func (s *OperationSuite) TestApply(c *C) {
+	ops := []Operation{
+		Operation{
+			Id:     CAST,
+			Field:  []string{"fieldA"},
+			Params: []string{"int"},
+		},
+		Operation{
+			Id:     CAST,
+			Field:  []string{"fieldB", "*", "subfieldB1"},
+			Params: []string{"date", "2006-01-02T15:04:05"},
+		},
+	}
+
+	var r map[string]interface{}
+	var err error
+
+	r = map[string]interface{}{}
+	err = ops[0].Apply(r)
+	c.Assert(err.Error(), Equals, "mutate: key `fieldA` was not found in subtree `map[]`")
+	err = ops[1].Apply(r)
+	c.Assert(err.Error(), Equals, "mutate: key `fieldB` was not found in subtree `map[]`")
+
+	r = map[string]interface{}{
+		"fieldZ": "blah",
+	}
+	err = ops[0].Apply(r)
+	c.Assert(err.Error(), Equals, "mutate: key `fieldA` was not found in subtree `map[fieldZ:blah]`")
+	err = ops[1].Apply(r)
+	c.Assert(err.Error(), Equals, "mutate: key `fieldB` was not found in subtree `map[fieldZ:blah]`")
+
+	r = map[string]interface{}{
+		"fieldA": "not int",
+		"fieldB": []interface{}{
+			map[string]interface{}{
+				"subfieldB1": "not date",
+			},
+		},
+		"fieldZ": "blah",
+	}
+	err = ops[0].Apply(r)
+	c.Assert(err, NotNil)
+	c.Assert(r["fieldA"], Equals, "not int")
+	err = ops[1].Apply(r)
+	c.Assert(err, NotNil)
+	c.Assert((r["fieldB"].([]interface{})[0]).(map[string]interface{})["subfieldB1"], Equals, "not date")
+
+	r = map[string]interface{}{
+		"fieldA": "1234",
+		"fieldB": []interface{}{
+			map[string]interface{}{
+				"subfieldB1": "2013-09-16T09:15:30",
+			},
+			map[string]interface{}{
+				"subfieldB1": "2015-09-16T09:15:30",
+			},
+		},
+		"fieldZ": "blah",
+	}
+	err = ops[0].Apply(r)
+	c.Assert(err, IsNil)
+	c.Assert(r["fieldA"], Not(Equals), "1234")
+	err = ops[1].Apply(r)
+	c.Assert(err, IsNil)
+	c.Assert((r["fieldB"].([]interface{})[0]).(map[string]interface{})["subfieldB1"], Not(Equals), "2013-09-16T09:15:30")
+	c.Assert((r["fieldB"].([]interface{})[1]).(map[string]interface{})["subfieldB1"], Not(Equals), "2015-09-16T09:15:30")
+}

--- a/src/processor/mutate_test.go
+++ b/src/processor/mutate_test.go
@@ -1,0 +1,90 @@
+package processor
+
+import (
+	"github.com/mcuadros/harvesterd/src/intf"
+	"github.com/mcuadros/harvesterd/src/processor/mutate"
+	. "gopkg.in/check.v1"
+)
+
+type MutateSuite struct{}
+
+var _ = Suite(&MutateSuite{})
+
+func (s *MutateSuite) TestMutateConfigParse(c *C) {
+	mc := MutateConfig{
+		Cast: []string{
+			"fieldA int",
+			"fieldB.*.subfieldB1 date 2006-01-02T15:04:05  'May 10th'    2015 '10th May 2015' '10-05-2015' ",
+		},
+	}
+	ops := mc.ParseOperations()
+
+	c.Assert(ops, HasLen, 2)
+	c.Assert(ops[0].Id, Equals, mutate.CAST)
+	c.Assert(ops[0].Field, HasLen, 1)
+	c.Assert(ops[0].Params, HasLen, 1)
+	c.Assert(ops[1].Id, Equals, mutate.CAST)
+	c.Assert(ops[1].Field, HasLen, 3)
+	c.Assert(ops[1].Params, HasLen, 6)
+}
+
+func (s *MutateSuite) TestNewMutate(c *C) {
+	mc := MutateConfig{
+		Cast: []string{
+			"fieldA int",
+			"fieldB.*.subfieldB1 date 2006-01-02T15:04:05",
+		},
+	}
+
+	m := NewMutate(&mc)
+
+	c.Assert(m, NotNil)
+}
+
+func (s *MutateSuite) TestNewMutateDo(c *C) {
+	mc := MutateConfig{
+		Cast: []string{
+			"fieldA int",
+			"fieldB.*.subfieldB1 date 2006-01-02T15:04:05",
+		},
+	}
+
+	m := NewMutate(&mc)
+
+	var r intf.Record
+	var output bool
+
+	r = intf.Record{}
+	output = m.Do(r)
+	c.Assert(output, Equals, true)
+
+	r = intf.Record{
+		"fieldZ": "blah",
+	}
+	output = m.Do(r)
+	c.Assert(output, Equals, true)
+
+	r = intf.Record{
+		"fieldA": "not int",
+		"fieldB": []interface{}{
+			map[string]interface{}{
+				"subfieldB1": "not date",
+			},
+		},
+		"fieldZ": "blah",
+	}
+	output = m.Do(r)
+	c.Assert(output, Equals, true)
+
+	r = intf.Record{
+		"fieldA": "1234",
+		"fieldB": []interface{}{
+			map[string]interface{}{
+				"subfieldB1": "2015-09-16T09:15:30",
+			},
+		},
+		"fieldZ": "blah",
+	}
+	output = m.Do(r)
+	c.Assert(output, Equals, true)
+}


### PR DESCRIPTION
This PR introduces a new processor for Harvester, inspired in the [mutate operator](https://www.elastic.co/guide/en/logstash/current/plugins-filters-mutate.html#plugins-filters-mutate-convert) of [Logstash](https://www.elastic.co/guide/en/logstash/current/introduction.html). It allows to change or update any field of the input structure using the declarative syntax of the config file.

For now only the casting function is implemented, with a syntax in the format:

```
[processor-mutate "alias"]
cast = field int
cast = complex.*.field date
```

where the fields in a map are specified, and array levels are noted with a `*`. Transformations are applied equally to all elements in arrays.