### PR TITLE
Cast Modifiers

### DIFF
--- a/src/processor/mutate/cast.go
+++ b/src/processor/mutate/cast.go
@@ -2,7 +2,9 @@ package mutate
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -16,6 +18,13 @@ func cast(value interface{}, fn string, params ...string) (interface{}, error) {
 	case INT:
 		switch value.(type) {
 		case string:
+			for _, param := range params {
+				switch param {
+				case "strip":
+					re := regexp.MustCompile("[0-9]+")
+					value = re.FindString(value.(string))
+				}
+			}
 			result, err := strconv.Atoi(value.(string))
 			if err != nil {
 				return value, err
@@ -35,6 +44,12 @@ func cast(value interface{}, fn string, params ...string) (interface{}, error) {
 			var err error
 			var result time.Time
 			for _, format := range params {
+				if format == "null" {
+					return nil, nil
+				}
+				if format == "present" && strings.ToLower(value.(string)) == "present" {
+					return time.Now(), nil
+				}
 				result, err = time.Parse(format, value.(string))
 				if err == nil {
 					break

--- a/src/processor/mutate/cast_test.go
+++ b/src/processor/mutate/cast_test.go
@@ -24,6 +24,11 @@ func (s *CastSuite) TestCastINT(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(value, Equals, 1234)
 
+	value = "int 1234 that will be stripped"
+	value, err = cast(value, INT, "strip")
+	c.Assert(err, IsNil)
+	c.Assert(value, Equals, 1234)
+
 	value = "not int"
 	value, err = cast(value, INT)
 	c.Assert(err, NotNil)
@@ -38,6 +43,7 @@ func (s *CastSuite) TestCastINT(c *C) {
 func (s *CastSuite) TestCastDATE(c *C) {
 	var value interface{}
 	var err error
+	var t0 time.Time
 	var t time.Time
 
 	value = "2015-09-16T09:15:30"
@@ -58,10 +64,23 @@ func (s *CastSuite) TestCastDATE(c *C) {
 	t = value.(time.Time)
 	c.Assert(t.Unix(), Equals, int64(1442394930))
 
-	value = "not date"
+	value = "Present"
+	t0 = time.Now()
+	value, err = cast(value, DATE, "2006-01-02T15:04:05", "present")
+	c.Assert(err, IsNil)
+	t = value.(time.Time)
+	c.Assert(t.Unix() >= t0.Unix(), Equals, true)
+	c.Assert(t.Unix() <= time.Now().Unix(), Equals, true)
+
+	value = "bad nullable date"
+	value, err = cast(value, DATE, "2006-01-02T15:04:05", "null")
+	c.Assert(err, IsNil)
+	c.Assert(value, IsNil)
+
+	value = "bad date"
 	value, err = cast(value, DATE, "2006-01-02T15:04:05")
 	c.Assert(err, NotNil)
-	c.Assert(value, Equals, "not date")
+	c.Assert(value, Equals, "bad date")
 
 	value = struct{}{}
 	value, err = cast(value, DATE, "2006-01-02T15:04:05")


### PR DESCRIPTION
This PR adds three modifiers to the cast operations, that can be declared in the config causing different effects.

### strip

Declaring the `strip` modifier in a string-to-int cast causes the string to be stripped of any non-numeric characters before being converted. Works by matching the first group of `[0-9]` characters found in the string.

```ini
cast = string_field int strip
```

### present

The `present` modifier in a list of date formats in a string-to-date cast matches the "present" string and converts the field to the current date (as returned by `time.Now()`).

```ini
cast = string_field date 'January 2006' 2006 present
```

### null

The `null` modifier will default the field to `nil` in a string-to-date cast if any of the previous formats didn't match the input string. Any date formats defined after the `null` modifier will be ignored.

```ini
cast = string_field date 'January 2006' 2006 null
```
